### PR TITLE
Allo Zope Public License.

### DIFF
--- a/check_pip_licenses
+++ b/check_pip_licenses
@@ -46,6 +46,7 @@ ALLOWED_LICENSES = [
     'Public Domain',
     'Python Software Foundation License',
     'new BSD',
+    'Zope Public License',
 ]
 
 

--- a/check_pip_licenses
+++ b/check_pip_licenses
@@ -6,7 +6,6 @@ from piplicenses import main
 
 IGNORE_PACKAGES = [
   'aiofiles',
-  'flake8-logging-format'
   'facebook-business',
   'GPy',
   'GPyOpt',


### PR DESCRIPTION
- fFix syntax error and remove flake8-logging-format for ignored packages.
- Allow Zope Public License because it is fine.
