### PR TITLE
Adding new license "The Unlicense (Unlicense)"

### DIFF
--- a/check_pip_licenses
+++ b/check_pip_licenses
@@ -49,9 +49,10 @@ ALLOWED_LICENSES = [
     'MIT License, Apache Software License',
     'MIT',
     'Mozilla Public License 2.0 (MPL 2.0)',
+    'new BSD',
     'Public Domain',
     'Python Software Foundation License',
-    'new BSD',
+    'The Unlicense (Unlicense)',
     'Zope Public License',
 ]
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/1199900217963069/1203496448562373/f

One of Network-Services [sub-dependencies has started using](https://github.com/tox-dev/py-filelock/commit/b8b6f2bdf673bbc404769c8ad749fcd9374af691) [The Unlicense](https://opensource.org/licenses/Unlicense) license and hence [the tests are now failing](https://github.com/adjust/networks-service/actions/runs/3627257958/jobs/6117112443#step:10:94).