### PR TITLE
Update check_pip_licenses

### DIFF
--- a/check_pip_licenses
+++ b/check_pip_licenses
@@ -23,6 +23,7 @@ IGNORED_PACKAGES = [
   'GPy',
   'GPyOpt',
   'numexpr',
+  'pathable',
   'types-orjson',
 ]
 


### PR DESCRIPTION
Still trying to figure out why `pathable` is having an issue with the license, since it uses apache 2, and this License type is allowed.

Nevertheless, I think we are save to ignore it for now.
![image](https://user-images.githubusercontent.com/5083518/216995071-de4e8157-ca6f-4834-868f-7e7eb8ca5992.png)
![image](https://user-images.githubusercontent.com/5083518/216995154-3b63e8eb-54d5-49d2-856d-4e67f0bc0907.png)
![image](https://user-images.githubusercontent.com/5083518/216995350-428dec14-d9d9-42e2-ab51-73a96ebc857e.png)

