### PR TITLE
Add stdlib-list to the list of ignored packages

### DIFF
--- a/check_pip_licenses
+++ b/check_pip_licenses
@@ -24,6 +24,7 @@ IGNORED_PACKAGES = [
   'GPyOpt',  # BSD-3: https://github.com/SheffieldML/GPyOpt/blob/master/LICENSE.txt
   'numexpr',  # MIT: https://github.com/pydata/numexpr/blob/master/LICENSE.txt
   'pathable',  # Apache 2.0: https://github.com/p1c2u/pathable/blob/master/LICENSE
+  'stdlib-list',  # MIT: https://github.com/pypi/stdlib-list/blob/main/LICENSE
   'types-orjson',  # Apache 2.0: https://github.com/python/typeshed/blob/main/LICENSE
 ]
 


### PR DESCRIPTION
This library recently released a [new tag](https://github.com/pypi/stdlib-list/tags) and it has "UNKNOWN" as a license. It was MIT. This causes our CI to fail